### PR TITLE
Add NonEmptyPinboard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl<T: Clone> NonEmptyPinboard<T> {
         // compiler).
         match self.0.read() {
             Some(t) => t,
-            None => unreachable!(),
+            None => unreachable!("Inner pointer was unexpectedly null"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,9 @@ impl<T: Clone> NonEmptyPinboard<T> {
         // Unwrap the option returned by the inner `Pinboard`. This will never panic, because it's
         // impossible for this `Pinboard` to be empty (though it's not possible to prove this to the
         // compiler).
-        self.0.read().unwrap()
+        self.0.read().expect("Inner pointer was unexpectedly null. This should be impossible. \
+                              Consider raising an issue at \
+                              https://github.com/bossmc/pinboard/issues.")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,29 @@ impl<T: Clone> Drop for Pinboard<T> {
     }
 }
 
+/// An wrapper around a `Pinboard` which provides the guarantee it is never empty.
+pub struct NonEmptyPinboard<T: Clone>(Pinboard<T>);
+
+impl<T: Clone> NonEmptyPinboard<T> {
+    /// Create a new `NonEmptyPinboard` instance holding the given value.
+    pub fn new(t: T) -> NonEmptyPinboard<T> {
+        NonEmptyPinboard(Pinboard::new(t))
+    }
+
+    /// Update the value stored in the `NonEmptyPinboard`.
+    pub fn set(&self, t: T) {
+        self.0.set(t)
+    }
+
+    /// Get a copy of the latest (well, recent) version of the posted data.
+    pub fn read(&self) -> T {
+        // Unwrap the option returned by the inner `Pinboard`. This will never panic, because it's
+        // impossible for this `Pinboard` to be empty (though it's not possible to prove this to the
+        // compiler).
+        self.0.read().unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,5 +175,13 @@ mod tests {
             scope.spawn(|| consume(&t));
             scope.spawn(|| consume(&t));
         })
+    }
+
+    #[test]
+    fn non_empty_pinboard() {
+        let t = NonEmptyPinboard::<u32>::new(3);
+        assert_eq!(3, t.read());
+        t.set(4);
+        assert_eq!(4, t.read());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,18 +83,21 @@ impl<T: Clone> NonEmptyPinboard<T> {
     }
 
     /// Update the value stored in the `NonEmptyPinboard`.
+    #[inline]
     pub fn set(&self, t: T) {
         self.0.set(t)
     }
 
     /// Get a copy of the latest (well, recent) version of the posted data.
+    #[inline]
     pub fn read(&self) -> T {
         // Unwrap the option returned by the inner `Pinboard`. This will never panic, because it's
         // impossible for this `Pinboard` to be empty (though it's not possible to prove this to the
         // compiler).
-        self.0.read().expect("Inner pointer was unexpectedly null. This should be impossible. \
-                              Consider raising an issue at \
-                              https://github.com/bossmc/pinboard/issues.")
+        match self.0.read() {
+            Some(t) => t,
+            None => unreachable!(),
+        }
     }
 }
 


### PR DESCRIPTION
This new variant of `Pinboard` can never be empty.

This is useful if the user doesn't want to have to deal with handling `Option`s as a result of `Pinboard::read`, and they don't mind the lack of `Pinboard::clear`.

The implementation uses `unwrap`s, as we can't convince the compiler that the underlying `Atomic` pointer is never null.