### PR TITLE
Switch to using crossbeam-epoch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,7 @@ version = "1.4.1"
 repository = "bossmc/pinboard"
 
 [dependencies]
+crossbeam-epoch = "0.2.0"
+
+[dev-dependencies]
 crossbeam = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [
 license = "MIT"
 name = "pinboard"
 repository = "https://github.com/bossmc/pinboard"
-version = "1.4.1"
+version = "2.0.0"
 
 [badges.travis-ci]
 repository = "bossmc/pinboard"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install from crates.io by adding `pinboard` to your `Cargo.toml`:
 
 ```
 [dependencies]
-pinboard = "1.4.0"
+pinboard = "2.0.0"
 ```
 
 Now you can create a Pinboard, share it between your users (be they `Futures`, threads or really anything else) and start sharing data!

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -1,0 +1,26 @@
+extern crate pinboard;
+extern crate crossbeam;
+
+#[derive(Clone)]
+struct Test(Box<u32>);
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("Dropping");
+    }
+}
+
+fn main() {
+    let p = pinboard::Pinboard::new(Test(Box::new(0u32)));
+
+    crossbeam::scope(|s| {
+        s.spawn(|| {
+            for i in 0..1000 {
+                println!("Modifying");
+                p.set(Test(Box::new(i)));
+            }
+        });
+    });
+
+    println!("Exiting");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@ use epoch::{Atomic, Owned, Shared, pin};
 use std::sync::atomic::Ordering::*;
 
 /// An instance of a `Pinboard`, holds a shared, mutable, eventually-consistent reference to a `T`.
-pub struct Pinboard<T: Clone>(Atomic<T>);
+pub struct Pinboard<T: Clone + 'static>(Atomic<T>);
 
-impl<T: Clone> Pinboard<T> {
+impl<T: Clone + 'static> Pinboard<T> {
     /// Create a new `Pinboard` instance holding the given value.
     pub fn new(t: T) -> Pinboard<T> {
         let t = Owned::new(t);
@@ -70,29 +70,29 @@ impl<T: Clone> Pinboard<T> {
     }
 }
 
-impl<T: Clone> Default for Pinboard<T> {
+impl<T: Clone + 'static> Default for Pinboard<T> {
     fn default() -> Pinboard<T> {
         Pinboard(Atomic::null())
     }
 }
 
-impl<T: Clone> Drop for Pinboard<T> {
+impl<T: Clone + 'static> Drop for Pinboard<T> {
     fn drop(&mut self) {
         // Make sure any stored data is marked for deletion
         self.clear();
     }
 }
 
-impl<T: Clone> From<Option<T>> for Pinboard<T> {
+impl<T: Clone + 'static> From<Option<T>> for Pinboard<T> {
     fn from(src: Option<T>) -> Pinboard<T> {
         src.map(Pinboard::new).unwrap_or_default()
     }
 }
 
 /// An wrapper around a `Pinboard` which provides the guarantee it is never empty.
-pub struct NonEmptyPinboard<T: Clone>(Pinboard<T>);
+pub struct NonEmptyPinboard<T: Clone + 'static>(Pinboard<T>);
 
-impl<T: Clone> NonEmptyPinboard<T> {
+impl<T: Clone + 'static> NonEmptyPinboard<T> {
     /// Create a new `NonEmptyPinboard` instance holding the given value.
     pub fn new(t: T) -> NonEmptyPinboard<T> {
         NonEmptyPinboard(Pinboard::new(t))
@@ -119,7 +119,7 @@ impl<T: Clone> NonEmptyPinboard<T> {
 
 macro_rules! debuggable {
     ($struct:ident, $trait:ident) => {
-        impl<T: Clone> ::std::fmt::$trait for $struct<T> where T: ::std::fmt::$trait {
+        impl<T: Clone + 'static> ::std::fmt::$trait for $struct<T> where T: ::std::fmt::$trait {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
                 write!(f, "{}(", stringify!($struct))?;
                 ::std::fmt::$trait::fmt(&self.read(), f)?;


### PR DESCRIPTION
This switches to use the new epoch collector in crossbeam-epoch, this library allows configuring a "Deferred function" to be called when sufficient epochs have passed to ensure any references in the deferred function are the last remaining ones.

This allows us to `drop` the deleted elements from the pinboard, fixing #7 without a custom crossbeam patch.