### PR TITLE
Remove `Clone` bound from `Pinboard`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [
 license = "MIT"
 name = "pinboard"
 repository = "https://github.com/bossmc/pinboard"
-version = "2.1.0"
+version = "2.2.0"
 
 [badges.travis-ci]
 repository = "bossmc/pinboard"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,19 +12,34 @@
 //!     * Writes from one thread can overwrite writes from another thread
 //! * No in-place mutation:
 //!     * The only write primitive completely overwrites the data on the `Pinboard`
-//! * Requires `Clone`:
-//!     * All reads return a clone of the data, decoupling the lifetime of the read value from the
-//!     data stored in the global reference.
 
 extern crate crossbeam_epoch as epoch;
 
-use epoch::{Atomic, Owned, Shared, pin};
-use std::sync::atomic::Ordering::*;
+use epoch::{pin, Atomic, Guard, Owned, Shared};
+use std::{ops::Deref, sync::atomic::Ordering::*};
 
 /// An instance of a `Pinboard`, holds a shared, mutable, eventually-consistent reference to a `T`.
-pub struct Pinboard<T: Clone + 'static>(Atomic<T>);
+pub struct Pinboard<T: 'static>(Atomic<T>);
 
-impl<T: Clone + 'static> Pinboard<T> {
+/// Stores a pointer to a `T`, alongside a guard which protects the data from garbage collection.
+///
+/// Obtained by calling [`Pinboard::get_ref`] or [`NonEmptyPinboard::get_ref`].
+pub struct GuardedRef<T> {
+    // We never use guard, we just hold onto it to protect the data behind the pointer
+    #[allow(dead_code)]
+    guard: Guard,
+    ptr: *const T,
+}
+
+impl<T> Deref for GuardedRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &(*self.ptr) }
+    }
+}
+
+impl<T: 'static> Pinboard<T> {
     /// Create a new `Pinboard` instance holding the given value.
     pub fn new(t: T) -> Pinboard<T> {
         let t = Owned::new(t);
@@ -61,6 +76,20 @@ impl<T: Clone + 'static> Pinboard<T> {
         }
     }
 
+    /// Get an immutable reference to a recent version of the posted data, protected from deletion by a guard.
+    pub fn get_ref(&self) -> Option<GuardedRef<T>> {
+        let guard = pin();
+        let t = self.0.load(Acquire, &guard);
+        if t.is_null() {
+            None
+        } else {
+            let ptr = t.as_raw();
+            Some(GuardedRef { guard, ptr })
+        }
+    }
+}
+
+impl<T: Clone + 'static> Pinboard<T> {
     /// Get a copy of the latest (well, recent) version of the posted data.
     pub fn read(&self) -> Option<T> {
         let guard = pin();
@@ -75,29 +104,29 @@ impl<T: Clone + 'static> Pinboard<T> {
     }
 }
 
-impl<T: Clone + 'static> Default for Pinboard<T> {
+impl<T: 'static> Default for Pinboard<T> {
     fn default() -> Pinboard<T> {
         Self::new_empty()
     }
 }
 
-impl<T: Clone + 'static> Drop for Pinboard<T> {
+impl<T: 'static> Drop for Pinboard<T> {
     fn drop(&mut self) {
         // Make sure any stored data is marked for deletion
         self.clear();
     }
 }
 
-impl<T: Clone + 'static> From<Option<T>> for Pinboard<T> {
+impl<T: 'static> From<Option<T>> for Pinboard<T> {
     fn from(src: Option<T>) -> Pinboard<T> {
         src.map(Pinboard::new).unwrap_or_default()
     }
 }
 
 /// An wrapper around a `Pinboard` which provides the guarantee it is never empty.
-pub struct NonEmptyPinboard<T: Clone + 'static>(Pinboard<T>);
+pub struct NonEmptyPinboard<T: 'static>(Pinboard<T>);
 
-impl<T: Clone + 'static> NonEmptyPinboard<T> {
+impl<T: 'static> NonEmptyPinboard<T> {
     /// Create a new `NonEmptyPinboard` instance holding the given value.
     pub fn new(t: T) -> NonEmptyPinboard<T> {
         NonEmptyPinboard(Pinboard::new(t))
@@ -109,6 +138,20 @@ impl<T: Clone + 'static> NonEmptyPinboard<T> {
         self.0.set(t)
     }
 
+    /// Get an immutable reference to a recent version of the posted data, protected from deletion by a guard.
+    #[inline]
+    pub fn get_ref(&self) -> GuardedRef<T> {
+        // Unwrap the option returned by the inner `Pinboard`. This will never panic, because it's
+        // impossible for this `Pinboard` to be empty (though it's not possible to prove this to the
+        // compiler).
+        match self.0.get_ref() {
+            Some(t) => t,
+            None => unreachable!("Inner pointer was unexpectedly null"),
+        }
+    }
+}
+
+impl<T: Clone + 'static> NonEmptyPinboard<T> {
     /// Get a copy of the latest (well, recent) version of the posted data.
     #[inline]
     pub fn read(&self) -> T {
@@ -124,14 +167,17 @@ impl<T: Clone + 'static> NonEmptyPinboard<T> {
 
 macro_rules! debuggable {
     ($struct:ident, $trait:ident) => {
-        impl<T: Clone + 'static> ::std::fmt::$trait for $struct<T> where T: ::std::fmt::$trait {
+        impl<T: Clone + 'static> ::std::fmt::$trait for $struct<T>
+        where
+            T: ::std::fmt::$trait,
+        {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
                 write!(f, "{}(", stringify!($struct))?;
                 ::std::fmt::$trait::fmt(&self.read(), f)?;
                 write!(f, ")")
             }
         }
-    }
+    };
 }
 
 debuggable!(Pinboard, Debug);
@@ -188,7 +234,8 @@ mod tests {
         crossbeam::scope(|scope| {
             scope.spawn(|_| produce(&t));
             scope.spawn(|_| consume(&t));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -200,7 +247,8 @@ mod tests {
             scope.spawn(|_| produce(&t));
             scope.spawn(|_| produce(&t));
             scope.spawn(|_| consume(&t));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -212,7 +260,8 @@ mod tests {
             scope.spawn(|_| consume(&t));
             scope.spawn(|_| consume(&t));
             scope.spawn(|_| consume(&t));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -226,7 +275,8 @@ mod tests {
             scope.spawn(|_| consume(&t));
             scope.spawn(|_| consume(&t));
             scope.spawn(|_| consume(&t));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,15 +92,7 @@ impl<T: 'static> Pinboard<T> {
 impl<T: Clone + 'static> Pinboard<T> {
     /// Get a copy of the latest (well, recent) version of the posted data.
     pub fn read(&self) -> Option<T> {
-        let guard = pin();
-        unsafe {
-            let t = self.0.load(Acquire, &guard);
-            if t.is_null() {
-                None
-            } else {
-                Some(t.deref().clone())
-            }
-        }
+        Some(self.get_ref()?.clone())
     }
 }
 
@@ -155,13 +147,7 @@ impl<T: Clone + 'static> NonEmptyPinboard<T> {
     /// Get a copy of the latest (well, recent) version of the posted data.
     #[inline]
     pub fn read(&self) -> T {
-        // Unwrap the option returned by the inner `Pinboard`. This will never panic, because it's
-        // impossible for this `Pinboard` to be empty (though it's not possible to prove this to the
-        // compiler).
-        match self.0.read() {
-            Some(t) => t,
-            None => unreachable!("Inner pointer was unexpectedly null"),
-        }
+        self.get_ref().clone()
     }
 }
 


### PR DESCRIPTION
This PR adds a new read primitive, `Pinboard::get_ref`, which does not require `Clone`. This is useful in cases where reads are frequent and/or clones are expensive.

In order to ensure the referenced data is not destroyed, `get_ref` returns a `GuardedRef` which stores the `Guard` alongside a raw pointer to the data. A raw pointer is used rather than a `Shared` pointer because the `Shared` cannot be returned alongside the `Guard` which it references. When the `GuardedRef` is dropped, so too is the `Guard`, allowing the epoch to advance.

The new `GuardedRef` struct implements `Deref` so that it can be used as an immutable reference. The `unsafe` read code is now contained in `GuardedRef::deref`.

To avoid duplicating null-check and loading logic, `read` now uses `get_ref` under the hood. As such, `get_ref` is somewhat covered by the existing tests and examples.

Many thanks for this great library; it greatly simplified memory management for me when trying to implement a lock-free algorithm. My apologies if I have missed an obvious issue with this PR.