### PR TITLE
Add implementations of `Debug`/`Display` to `GuardedRef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.0] - 2023-04-17
 
+### Fixed
+
+- Move to the rust 2021 edition
+
 ### Added
 
 - Implement `Pinboard::get_ref` to safely borrow the data in the pinboard
   - In particular this works for non-`Clone` types
+  - The returned item can `Deref` to the stored `&T` and inherits `Debug`/`Display` implementations
 
 ## [2.1.0] - 2020-11-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 name = "pinboard"
 repository = "https://github.com/bossmc/pinboard"
 version = "2.2.0"
-edition = "2018"
+edition = "2021"
 
 [badges.travis-ci]
 repository = "bossmc/pinboard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 name = "pinboard"
 repository = "https://github.com/bossmc/pinboard"
 version = "2.2.0"
+edition = "2018"
 
 [badges.travis-ci]
 repository = "bossmc/pinboard"

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ pinboard = "2.0.0"
 Now you can create a Pinboard, share it between your users (be they `Futures`, threads or really anything else) and start sharing data!
 
 ```rust,no_run
-use pinboard::Pinboard;
+use pinboard::NonEmptyPinboard;
 use std::{thread, time::Duration};
 
-let weather_report = Pinboard::new("Sunny");
+let weather_report = NonEmptyPinboard::new("Sunny");
 
 crossbeam::scope(|scope| {
   scope.spawn(|_| {
@@ -34,7 +34,7 @@ crossbeam::scope(|scope| {
   });
   scope.spawn(|_| {
     loop {
-      println!("The weather is {:?}", weather_report.get_ref().as_deref());
+      println!("The weather is {}", weather_report.get_ref());
       thread::sleep(Duration::from_secs(1));
     }
   });

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -19,7 +19,8 @@ fn main() {
                 }
             });
         }
-    }).unwrap();
+    })
+    .unwrap();
 
     println!("Exiting");
 }

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -1,6 +1,3 @@
-extern crate pinboard;
-extern crate crossbeam;
-
 #[derive(Clone)]
 struct Test(u32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,21 @@ macro_rules! debuggable {
     };
 }
 
+macro_rules! debuggable_ref {
+    ($struct:ident, $trait:ident) => {
+        impl<T: Clone + 'static> ::std::fmt::$trait for $struct<T>
+        where
+            T: ::std::fmt::$trait,
+        {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+                write!(f, "{}(", stringify!($struct))?;
+                ::std::fmt::$trait::fmt(self, f)?;
+                write!(f, ")")
+            }
+        }
+    };
+}
+
 debuggable!(Pinboard, Debug);
 debuggable!(NonEmptyPinboard, Debug);
 debuggable!(NonEmptyPinboard, Binary);
@@ -180,6 +195,15 @@ debuggable!(NonEmptyPinboard, Octal);
 debuggable!(NonEmptyPinboard, Pointer);
 debuggable!(NonEmptyPinboard, UpperExp);
 debuggable!(NonEmptyPinboard, UpperHex);
+debuggable_ref!(GuardedRef, Debug);
+debuggable_ref!(GuardedRef, Binary);
+debuggable_ref!(GuardedRef, Display);
+debuggable_ref!(GuardedRef, LowerExp);
+debuggable_ref!(GuardedRef, LowerHex);
+debuggable_ref!(GuardedRef, Octal);
+debuggable_ref!(GuardedRef, Pointer);
+debuggable_ref!(GuardedRef, UpperExp);
+debuggable_ref!(GuardedRef, UpperHex);
 
 #[cfg(test)]
 mod tests {
@@ -205,7 +229,7 @@ mod tests {
         t.clear();
     }
 
-    fn check_debug<T: ::std::fmt::Debug>(_: T) {}
+    fn check_debug<T: ::std::fmt::Debug>(_: &T) {}
 
     #[test]
     fn it_works() {
@@ -280,8 +304,10 @@ mod tests {
     #[test]
     fn debuggable() {
         let t = Pinboard::<i32>::new(3);
-        check_debug(t);
+        check_debug(&t);
         let t = NonEmptyPinboard::<i32>::new(2);
-        check_debug(t);
+        check_debug(&t);
+        let tr = t.get_ref();
+        check_debug(&tr);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,7 @@
 #[cfg(doctest)]
 pub struct README;
 
-extern crate crossbeam_epoch as epoch;
-
-use epoch::{pin, Atomic, Guard, Owned, Shared};
+use crossbeam_epoch::{pin, Atomic, Guard, Owned, Shared};
 use std::{ops::Deref, sync::atomic::Ordering::*};
 
 /// An instance of a `Pinboard`, holds a shared, mutable, eventually-consistent reference to a `T`.
@@ -161,7 +159,7 @@ macro_rules! debuggable {
         where
             T: ::std::fmt::$trait,
         {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
                 write!(f, "{}(", stringify!($struct))?;
                 ::std::fmt::$trait::fmt(&self.read(), f)?;
                 write!(f, ")")
@@ -176,7 +174,7 @@ macro_rules! debuggable_ref {
         where
             T: ::std::fmt::$trait,
         {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
                 write!(f, "{}(", stringify!($struct))?;
                 ::std::fmt::$trait::fmt(self, f)?;
                 write!(f, ")")
@@ -207,11 +205,9 @@ debuggable_ref!(GuardedRef, UpperHex);
 
 #[cfg(test)]
 mod tests {
-    extern crate crossbeam;
     use super::*;
-    use std::fmt::Display;
 
-    fn consume<T: Clone + Display>(t: &Pinboard<T>) {
+    fn consume<T: Clone + ::std::fmt::Display>(t: &Pinboard<T>) {
         loop {
             match t.read() {
                 Some(_) => {}


### PR DESCRIPTION
Also do some housekeeping, like edition upgrades, clippy lints, formatting, etc.